### PR TITLE
Improve MacOS Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,21 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 
-set(GSL_LIB_DEPENDS gsl gslcblas m)
+
+if (APPLE)
+  set(GSL_LIB_DEPENDS
+    /usr/local/lib/libgsl.a
+    /usr/local/lib/libgslcblas.a
+    m
+  )
+else()
+  set(GSL_LIB_DEPENDS
+    gsl
+    gslcblas
+    m
+)
+endif()
+
 
 include_directories(${CMAKE_CURRENT_LIST_DIR}/c++/include)
 
@@ -31,10 +45,14 @@ add_library(persistence_filter_utils SHARED
 	${CMAKE_CURRENT_LIST_DIR}/c++/src/persistence_filter_utils.cc
 )
 
+target_link_libraries(persistence_filter_utils
+  ${GSL_LIB_DEPENDS}
+)
+
 add_library(persistence_filter SHARED ${CMAKE_CURRENT_LIST_DIR}/c++/src/persistence_filter.cc)
 target_link_libraries(persistence_filter
-  persistence_filter_utils
   ${GSL_LIB_DEPENDS}
+  persistence_filter_utils
 )
 
 
@@ -46,7 +64,12 @@ target_link_libraries(persistence_filter_test persistence_filter persistence_fil
 
 find_package(Boost)
 IF(Boost_FOUND)
-  include_directories("${Boost_INCLUDE_DIRS}" "/usr/include/python2.7")
+  if (APPLE)
+    include_directories("${Boost_INCLUDE_DIRS}" "/usr/include/python2.7")
+  else()
+    include_directories("${Boost_INCLUDE_DIRS}" "/usr/include/python2.7")
+  endif()
+    
   SET(Boost_USE_STATIC_LIBS OFF)
   SET(Boost_USE_MULTITHREADED ON)
   SET(Boost_USE_STATIC_RUNTIME OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 #SET(CMAKE_BUILD_TYPE "DEBUG")
 SET(CMAKE_BUILD_TYPE "RELEASE")
@@ -15,9 +15,14 @@ ENDIF(CMAKE_BUILD_TYPE MATCHES RELEASE)
 
 project(PersistenceFilter)
 
+message (STATUS "${CMAKE_CXX_COMPILER_ID}")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
+    message(STATUS "GNUCXX")
     add_definitions(-std=gnu++0x)  # Tell the compiler to compile with C++11 
+    add_definitions("-Wall")  # Display all warnings
+else()
+    add_definitions(-std=c++11)  # Tell the compiler to compile with C++11 
     add_definitions("-Wall")  # Display all warnings
 endif()
 
@@ -65,7 +70,7 @@ target_link_libraries(persistence_filter_test persistence_filter persistence_fil
 find_package(Boost)
 IF(Boost_FOUND)
   if (APPLE)
-    include_directories("${Boost_INCLUDE_DIRS}" "/usr/include/python2.7")
+    include_directories("${Boost_INCLUDE_DIRS}" "/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9")
   else()
     include_directories("${Boost_INCLUDE_DIRS}" "/usr/include/python2.7")
   endif()
@@ -73,15 +78,18 @@ IF(Boost_FOUND)
   SET(Boost_USE_STATIC_LIBS OFF)
   SET(Boost_USE_MULTITHREADED ON)
   SET(Boost_USE_STATIC_RUNTIME OFF)
-  find_package(Boost COMPONENTS python)
+  find_package(Boost COMPONENTS python3)
+  find_package(PythonLibs 3.9 REQUIRED)
+
+message(STATUS "${PYTHON_LIBRARIES}")
 
   # Build the Python persistence_filter_utils library
   add_library(python_persistence_filter_utils SHARED python/python_persistence_filter_utils.cc)
-  target_link_libraries(python_persistence_filter_utils persistence_filter_utils ${Boost_LIBRARIES} ${GSL_LIB_DEPENDS})
+  target_link_libraries(python_persistence_filter_utils persistence_filter_utils ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} ${GSL_LIB_DEPENDS} )
 
   # Build the Python persistence_filter library
   add_library(python_persistence_filter SHARED python/python_persistence_filter.cc)
-  target_link_libraries(python_persistence_filter persistence_filter ${Boost_LIBRARIES})
+  target_link_libraries(python_persistence_filter persistence_filter ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} )
 
 
 ELSEIF(NOT Boost_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,6 @@ ENDIF(CMAKE_BUILD_TYPE MATCHES RELEASE)
 
 project(PersistenceFilter)
 
-message (STATUS "${CMAKE_CXX_COMPILER_ID}")
-
 if(CMAKE_COMPILER_IS_GNUCXX)
     message(STATUS "GNUCXX")
     add_definitions(-std=gnu++0x)  # Tell the compiler to compile with C++11 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,34 @@ year = 2016,
 }
 ```
 
+### Compiling on MacOS
+
+In order to get the persistence filter code to compile on MacOS I had to make a few modifications to the `CMakeLists.txt` file. It is worth taking a look at the Apple-specific content running in the updated `CMakeLists.txt` file, as you may have to modify some paths to make things work properly on your machine.
+
+Before doing anything, I had to install a few packages from `brew`:
+```
+# Install libgsl (GNU Scientific Library)
+brew install gsl
+
+# Install Boost Python3
+brew install boost-python3
+```
+
+Now you should be ready to try to compile. I prefixed my CMake command below with the path to the Boost library directory so that CMake could find it. Maybe there is a better way, though.
+
+From the project root directory:
+```
+mkdir build
+cd build
+BOOST_LIBRARYDIR=/usr/local/Cellar/boost-python3/1.78.0/lib cmake ..
+make
+```
+
+Now you can test the code by running:
+```
+./persistence_filter_test
+```
+
 ### Copyright and License
 
 The C++ and Python implementations of the Persistence Filter contained herein are copyright (C) 2016 by David M. Rosen, and are distributed under the terms of the GNU General Public License (GPL) version 3 (or later).  Please see the file LICENSE for more information.

--- a/c++/src/persistence_filter_test.cc
+++ b/c++/src/persistence_filter_test.cc
@@ -17,7 +17,7 @@ double P_F = .01;
 
 std::function<double(double)> logS_T = std::bind(log_general_purpose_survival_function, std::placeholders::_1, lambda_l, lambda_u);
 
-auto S_T = [=](double t) { return gsl_sf_exp(logS_T(t)); };
+auto S_T = [](double t) { return gsl_sf_exp(logS_T(t)); };
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
This PR makes the persistence filter code compatible with the MacOS.

Specifically, I added instructions for getting dependencies and compiling on MacOS and additionally made the following modifications:
- Specified `-std=c++11` for all non-GNU CXX compiles (Apple uses AppleClang).
- Correctly link against `libgsl` when it is installed via brew on Apple machines. This is protected by an `if (APPLE)` condition in `CMakeLists.txt` so it should have no compatibility issues.
- Link against Python 3.9 and Boost for MacOS machines. Note that this requires specifying the version number of `boost-python3` in the environment variable `BOOST_LIBRARYDIR` (see `README.md`). This also requires specifying the version of (and path to headers for) your Python installation.

There was also apparently a syntax error with a lambda capture in `persistence_filter_test.cc` (see the diff). This could have been some kind of library or compiler versioning issue, though. I'm not certain.

Caveats:
1. Specific version numbers are pinned and not retrieved from the system (to be honest, I'm not sure in all cases above _how_ to do this). Despite this, I've tried to include information in `README.md` about what to change for MacOS users who may have different versions of e.g. Python, Boost, etc, which I hope would be useful to a user needing to modify this information.
2. I haven't tested the modified version on a Linux machine, so I don't know for certain if I've made any breaking changes. I might recommend just pulling the latest off my fork and trying to compile on a Linux machine quickly if you have a development environment where this is possible?